### PR TITLE
Prepare release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@ Todos los cambios notables a este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2020-11-04
-### Added
-- Release inicial
-
+## [1.0.2] - 2021-02-02
+### Changed
+- Configura version de PHP 5.6.1.
 
 ## [1.0.1] - 2021-02-01
 ### Changed
 - Corrige [error en variables](https://github.com/TransbankDevelopers/transbank-plugin-opencart-webpay-rest/issues/7) de Producción ('LIVE') e Integración ('TEST').
 - Actualiza la versión de SDK PHP a la última disponible (1.10.1).
+
+## [1.0.0] - 2020-11-04
+### Added
+- Release inicial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.ht
 
 ## [1.0.2] - 2021-02-02
 ### Changed
-- Configura version de PHP 5.6.1.
+- Configura versión de PHP 5.6.1.
 
 ## [1.0.1] - 2021-02-01
 ### Changed


### PR DESCRIPTION
Set PHP version 5.6.1. on composer.json

Full diff: [TransbankDevelopers:1.0.1...chore/prepare-release-1.0.2](https://github.com/TransbankDevelopers/transbank-plugin-opencart-webpay-rest/compare/TransbankDevelopers:1.0.1...chore/prepare-release-1.0.2?expand=1)