### PR TITLE
Prepare release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Todos los cambios notables a este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 y este proyecto adhiere a [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2021-04-30
+### Fixed
+- Se arregla error que evitaba que el plugin se pudiese usar correctamente en modo producción
+
+
 ## [1.1.0] - 2021-04-09
 ### Changed
 - Se utiliza el nuevo SDK de PHP 2.0-beta


### PR DESCRIPTION
### Fixed
- Se arregla error que evitaba que el plugin se pudiese usar correctamente en modo producción


You can see the full diff [here](https://github.com/TransbankDevelopers/transbank-plugin-opencart-webpay-rest/compare/TransbankDevelopers:1.1.0...chore/prepare-release-1.1.1?expand=1)