### PR TITLE
chore: exclude docker folder from sonar analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,1 @@
-sonar.exclusions=src/upload/catalog/controller/extension/payment/libwebpay_rest/tcpdf/TCPDF/**, src/upload/catalog/controller/extension/payment/libwebpay_rest/log4php/**
+sonar.exclusions=src/upload/catalog/controller/extension/payment/libwebpay_rest/tcpdf/TCPDF/**, src/upload/catalog/controller/extension/payment/libwebpay_rest/log4php/**, docker-opencart3/**


### PR DESCRIPTION
Exclude docker folder from sonar cloud analysis to reduce security hotspots