### PR TITLE
fix: last plugin release version and opencart version

### DIFF
--- a/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
+++ b/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
@@ -4,7 +4,7 @@ use OpencartWebpayRest\TransbankSdkWebpay;
 
 require_once(DIR_SYSTEM . 'library/OpencartWebpayRest/TransbankSdkWebpay.php');
 require_once('LogHandler.php');
-
+require_once('/opt/bitnami/opencart/admin/index.php');
 class HealthCheck {
 
     var $commerceCode;

--- a/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
+++ b/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
@@ -55,9 +55,8 @@ class HealthCheck {
             if (preg_match("/define\('VERSION', '([^']+)'\);/", $fileContent, $matches)) {
                 return $matches[1];
             }
-        } else {
-            return 'Versión no encontrada';
         }
+            return 'Versión no encontrada';
     }
     // verifica si existe la extension y cual es la version de esta
     private function getCheckExtension($extension){

--- a/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
+++ b/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
@@ -126,7 +126,7 @@ class HealthCheck {
             'ecommerce' => $ecommerce,
             'ecommerce_version' => $data['current_ecommerce_version'],
             'current_plugin_version' => $data['current_plugin_version'],
-            'last_plugin_version' => $this->getPluginLastVersion($ecommerce, $data['current_ecommerce_version']) // ultimo declarado
+            'last_plugin_version' => $data['last_version_plugin'] // ultimo declarado
         );
         return $result;
     }

--- a/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
+++ b/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
@@ -91,6 +91,20 @@ class HealthCheck {
         return $version;
     }
 
+    private function getLastGitHubReleaseVersionPlugin($string){
+        $baseurl = 'https://api.github.com/repos/'.$string.'/releases/latest';
+        $agent = 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)';
+        $ch = curl_init();
+        curl_setopt($ch,CURLOPT_URL,$baseurl);
+        curl_setopt($ch,CURLOPT_RETURNTRANSFER,true);
+        curl_setopt($ch, CURLOPT_USERAGENT, $agent);
+        $content=curl_exec($ch);
+        curl_close($ch);
+        $con = json_decode($content, true);
+        $version = array_key_exists('tag_name',$con) ? $con['tag_name'] : '';
+        return $version;
+    }
+
     // funcion para obtener info de cada ecommerce, si el ecommerce es incorrecto o no esta seteado se escapa como respuesta "NO APLICA"
     private function getEcommerceInfo($ecommerce){
         $actualversion = TransbankSdkWebpay::PLUGIN_VERSION;

--- a/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
+++ b/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
@@ -16,9 +16,11 @@ class HealthCheck {
     var $fullResume;
     var $ecommerce;
     var $config;
+    var $configFile;
 
     public function __construct($config) {
         $this->config = $config;
+        $this->configFile = '/opt/bitnami/opencart/admin/index.php';
         $this->environment = $config['MODO'];
         $this->commerceCode = $config['COMMERCE_CODE'];
         $this->apiKey = $config['API_KEY'];

--- a/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
+++ b/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
@@ -4,7 +4,7 @@ use OpencartWebpayRest\TransbankSdkWebpay;
 
 require_once(DIR_SYSTEM . 'library/OpencartWebpayRest/TransbankSdkWebpay.php');
 require_once('LogHandler.php');
-require_once('/opt/bitnami/opencart/admin/index.php');
+
 class HealthCheck {
 
     var $commerceCode;
@@ -20,7 +20,7 @@ class HealthCheck {
 
     public function __construct($config) {
         $this->config = $config;
-        $this->configFile = '/opt/bitnami/opencart/admin/index.php';
+        $this->configFile = dirname(DIR_SYSTEM) . '/admin/index.php';
         $this->environment = $config['MODO'];
         $this->commerceCode = $config['COMMERCE_CODE'];
         $this->apiKey = $config['API_KEY'];

--- a/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
+++ b/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
@@ -106,13 +106,13 @@ class HealthCheck {
 
     // funcion para obtener info de cada ecommerce, si el ecommerce es incorrecto o no esta seteado se escapa como respuesta "NO APLICA"
     private function getEcommerceInfo($ecommerce){
-        $actualversion = $this->getLastGitHubReleaseVersion('opencart/opencart');
-        $lastversionplugin = $this->getLastGitHubReleaseVersion('TransbankDevelopers/transbank-plugin-opencart-webpay-rest');
-        $currentplugin = TransbankSdkWebpay::PLUGIN_VERSION;
+        $currentOpenCartVersion = $this->getOpenCartVersion();
+        $latestTransbankPluginVersion = $this->getLastGitHubReleaseVersion('TransbankDevelopers/transbank-plugin-opencart-webpay-rest');
+        $currentTransbankPluginVersion = TransbankSdkWebpay::PLUGIN_VERSION;
         $result = array(
-            'current_ecommerce_version' => $actualversion,
-            'current_plugin_version' => $currentplugin,
-            'last_version_plugin' => $lastversionplugin
+            'current_opencart_version' => $currentOpenCartVersion,
+            'current_transbank_plugin_version' => $currentTransbankPluginVersion,
+            'latest_transbank_plugin_version' => $latestTransbankPluginVersion
         );
         return $result;
     }
@@ -123,9 +123,9 @@ class HealthCheck {
         $data = $this->getEcommerceInfo($ecommerce);
         $result = array(
             'ecommerce' => $ecommerce,
-            'ecommerce_version' => $data['current_ecommerce_version'],
-            'current_plugin_version' => $data['current_plugin_version'],
-            'last_plugin_version' => $data['last_version_plugin'] // ultimo declarado
+            'ecommerce_version' => $data['current_opencart_version'],
+            'current_plugin_version' => $data['current_transbank_plugin_version'],
+            'last_plugin_version' => $data['latest_transbank_plugin_version'] // ultimo declarado
         );
         return $result;
     }

--- a/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
+++ b/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
@@ -107,13 +107,13 @@ class HealthCheck {
 
     // funcion para obtener info de cada ecommerce, si el ecommerce es incorrecto o no esta seteado se escapa como respuesta "NO APLICA"
     private function getEcommerceInfo($ecommerce){
-        $actualversion = TransbankSdkWebpay::PLUGIN_VERSION;
-        $lastversion = $this->getLastGitHubReleaseVersion('opencart/opencart');
+        $actualversion = $this->getLastGitHubReleaseVersion('opencart/opencart');
+        $lastversionplugin = $this->getLastGitHubReleaseVersionPlugin('TransbankDevelopers/transbank-plugin-opencart-webpay-rest');
         $currentplugin = TransbankSdkWebpay::PLUGIN_VERSION;
         $result = array(
             'current_ecommerce_version' => $actualversion,
-            'last_ecommerce_version' => $lastversion,
-            'current_plugin_version' => $currentplugin
+            'current_plugin_version' => $currentplugin,
+            'last_version_plugin' => $lastversionplugin
         );
         return $result;
     }

--- a/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
+++ b/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
@@ -91,24 +91,10 @@ class HealthCheck {
         return $version;
     }
 
-    private function getLastGitHubReleaseVersionPlugin($string){
-        $baseurl = 'https://api.github.com/repos/'.$string.'/releases/latest';
-        $agent = 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)';
-        $ch = curl_init();
-        curl_setopt($ch,CURLOPT_URL,$baseurl);
-        curl_setopt($ch,CURLOPT_RETURNTRANSFER,true);
-        curl_setopt($ch, CURLOPT_USERAGENT, $agent);
-        $content=curl_exec($ch);
-        curl_close($ch);
-        $con = json_decode($content, true);
-        $version = array_key_exists('tag_name',$con) ? $con['tag_name'] : '';
-        return $version;
-    }
-
     // funcion para obtener info de cada ecommerce, si el ecommerce es incorrecto o no esta seteado se escapa como respuesta "NO APLICA"
     private function getEcommerceInfo($ecommerce){
         $actualversion = $this->getLastGitHubReleaseVersion('opencart/opencart');
-        $lastversionplugin = $this->getLastGitHubReleaseVersionPlugin('TransbankDevelopers/transbank-plugin-opencart-webpay-rest');
+        $lastversionplugin = $this->getLastGitHubReleaseVersion('TransbankDevelopers/transbank-plugin-opencart-webpay-rest');
         $currentplugin = TransbankSdkWebpay::PLUGIN_VERSION;
         $result = array(
             'current_ecommerce_version' => $actualversion,

--- a/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
+++ b/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
@@ -139,9 +139,7 @@ class HealthCheck {
     3 => PatPass
     4 => OnePay
     */
-    private function getPluginLastVersion($ecommerce, $currentversion){
-        return 'Indefinido';
-    }
+
 
     // lista y valida extensiones/ modulos de php en servidor ademas mostrar version
     private function getExtensionsValidate(){

--- a/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
+++ b/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
@@ -49,7 +49,18 @@ class HealthCheck {
         }
         return $this->versioninfo;
     }
-
+    private function getOpenCartVersion() {
+        if (file_exists($this->configFile)) {
+            $fileContent = file_get_contents($this->configFile);
+            if (preg_match("/define\('VERSION', '([^']+)'\);/", $fileContent, $matches)) {
+                return $matches[1];
+            } else {
+                throw new Exception('No se pudo encontrar la versión de OpenCart.');
+            }
+        } else {
+            throw new Exception('El archivo admin/index.php no existe.');
+        }
+    }
     // verifica si existe la extension y cual es la version de esta
     private function getCheckExtension($extension){
         if (extension_loaded($extension)) {

--- a/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
+++ b/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
@@ -54,11 +54,9 @@ class HealthCheck {
             $fileContent = file_get_contents($this->configFile);
             if (preg_match("/define\('VERSION', '([^']+)'\);/", $fileContent, $matches)) {
                 return $matches[1];
-            } else {
-                throw new Exception('No se pudo encontrar la versión de OpenCart.');
             }
         } else {
-            throw new Exception('El archivo admin/index.php no existe.');
+            return 'Versión no encontrada';
         }
     }
     // verifica si existe la extension y cual es la version de esta


### PR DESCRIPTION
This PR add the last plugin release version and Opencart version

> Before the changes
![Captura de pantalla 2024-07-30 a la(s) 1 07 43 p  m](https://github.com/user-attachments/assets/da56777a-05ef-49e1-8ca7-4786746bd720)

> After the changes
![Captura de pantalla 2024-07-30 a la(s) 8 05 47 p  m](https://github.com/user-attachments/assets/52a8e293-4189-42c0-a399-b24060b7c8a4)
