### PR TITLE
fix: show webpay logo in checkout

### DIFF
--- a/src/upload/catalog/language/en-gb/extension/payment/webpay_rest.php
+++ b/src/upload/catalog/language/en-gb/extension/payment/webpay_rest.php
@@ -4,7 +4,7 @@ $_['heading_title'] = 'Gracias por comprar con %s';
 $_['button_confirm'] = 'Continuar a Webpay';
 
 // Text
-$_['text_title'] = 'Pago con Tarjetas de Cr&eacute;dito o Redcompra &nbsp; <img src="src="admin/view/image/payment/webpay_logo-small.svg" alt="WebPay" title="WebPay" align="middle" style="width: 80px;" />';
+$_['text_title'] = 'Pago con Tarjetas de Cr&eacute;dito o Redcompra &nbsp; <img src="admin/view/image/payment/webpay_logo-small.svg" alt="WebPay" title="WebPay" align="middle" style="width: 80px;" />';
 $_['text_response'] = 'Respuesta desde Webpay:';
 $_['text_success'] = 'Su pago fue recibido exitosamente.';
 $_['text_success_wait'] = '<b><span style="color: #FF0000">Por favor espere...</span></b> mientras finalizamos su orden. Si Ud. no es autom&aacute;ticamente redirigido en 10 segundos, por favor haga clic aqu&iacute;.';

--- a/src/upload/catalog/language/en-gb/extension/payment/webpay_rest.php
+++ b/src/upload/catalog/language/en-gb/extension/payment/webpay_rest.php
@@ -12,10 +12,10 @@ $_['text_failure'] = '¡Su pago termin&oacute; de forma inesperada!';
 $_['text_failure_wait'] = '<b><span style="color: #FF0000">Por favor espere...</span></b> Si Ud. no es autom&aacute;ticamente redirigido en 10 segundos, por favor haga clic aqu&iacute;.';
 
 // Error
-$_['error_required'] = 'Advertencia: Toda la informacion de pago es requerida';
-$_['error_general'] = 'Advertencia: Un error general ha ocurrido con la transacción, favor intente nuevamente.';
-$_['error_config'] = 'Advertencia: Error en el modulo de pago, favor revisar configuracion.';
-$_['error_conection_webpay'] = 'Error!: Ocurri&oacute; un error al intentar conectar con WebPay Plus. Por favor intenta mas tarde.';
+$_['error_required'] = 'Advertencia: Toda la informaci&oacute;n de pago es requerida';
+$_['error_general'] = 'Advertencia: Un error general ha ocurrido con la transacci&oacute;n, favor intente nuevamente.';
+$_['error_config'] = 'Advertencia: Error en el m&oacute;dulo de pago, favor revisar configuraci&oacute;n.';
+$_['error_conection_webpay'] = 'Error!: Ocurri&oacute; un error al intentar conectar con WebPay Plus. Por favor intenta m&aacute;s tarde.';
 $_['error_token'] = 'Error, no se ha podido obtener correctamente el token.';
 $_['error_response'] = 'Error en respuesta desde Webpay.';
-$_['error_invalid_cart'] = 'Error en el pago, carro inválido';
+$_['error_invalid_cart'] = 'Error en el pago, carro inv&aacute;lido';

--- a/src/upload/catalog/language/es-cl/extension/payment/webpay_rest.php
+++ b/src/upload/catalog/language/es-cl/extension/payment/webpay_rest.php
@@ -12,10 +12,10 @@ $_['text_failure'] = '¡Su pago termin&oacute; de forma inesperada!';
 $_['text_failure_wait'] = '<b><span style="color: #FF0000">Por favor espere...</span></b> Si Ud. no es autom&aacute;ticamente redirigido en 10 segundos, por favor haga clic aqu&iacute;.';
 
 // Error
-$_['error_required'] = 'Advertencia: Toda la informacion de pago es requerida';
-$_['error_general'] = 'Advertencia: Un error general ha ocurrido con la transacción, favor intente nuevamente.';
-$_['error_config'] = 'Advertencia: Error en el modulo de pago, favor revisar configuracion.';
-$_['error_conection_webpay'] = 'Error!: Ocurri&oacute; un error al intentar conectar con WebPay Plus. Por favor intenta mas tarde.';
+$_['error_required'] = 'Advertencia: Toda la informaci&oacute;n de pago es requerida';
+$_['error_general'] = 'Advertencia: Un error general ha ocurrido con la transacci&oacute;n, favor intente nuevamente.';
+$_['error_config'] = 'Advertencia: Error en el m&oacute;dulo de pago, favor revisar configuraci&oacute;n.';
+$_['error_conection_webpay'] = 'Error!: Ocurri&oacute; un error al intentar conectar con WebPay Plus. Por favor intenta m&aacute;s tarde.';
 $_['error_token'] = 'Error, no se ha podido obtener correctamente el token.';
 $_['error_response'] = 'Error en respuesta desde Webpay.';
-$_['error_invalid_cart'] = 'Error en el pago, carro inválido';
+$_['error_invalid_cart'] = 'Error en el pago, carro inv&aacute;lido';


### PR DESCRIPTION
This PR fixes an issue that prevented the Webpay logo from displaying on the payment page when the English language was selected.

## Test

### Show Webpay logo in checkout page
![image](https://github.com/user-attachments/assets/efeccccf-3f3c-48be-8d50-faf68a3660d3)
 