### PR TITLE
refactor: change variable name in getLastGitHubReleaseVersion function

### DIFF
--- a/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
+++ b/src/upload/catalog/controller/extension/payment/libwebpay_rest/HealthCheck.php
@@ -90,8 +90,8 @@ class HealthCheck {
     *
     * @return string The latest release version.
     */
-    private function getLastGitHubReleaseVersion($string): string{
-        $baseurl = 'https://api.github.com/repos/'.$string.'/releases/latest';
+    private function getLastGitHubReleaseVersion($repository): string{
+        $baseurl = 'https://api.github.com/repos/'.$repository.'/releases/latest';
         $agent = 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)';
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $baseurl);


### PR DESCRIPTION
This PR change variable name "string" of getLastGitHubReleaseVersion to "repository"
![captura](https://github.com/user-attachments/assets/a406d5d7-e8dd-4b36-b120-7058b8a825f6)
